### PR TITLE
Add a link to _earthaccess_ and bi-weekly hack days

### DIFF
--- a/approach/tooling.md
+++ b/approach/tooling.md
@@ -106,6 +106,11 @@ Using Edit \> Trim, it can be hard to control how fast the yellow Trim brackets 
 -   communications and technical writing (RMarkdown, bookdown, blogdown, Quarto)
 -   [RStudio and GitHub setup instructions](https://openscapes.github.io/series/how-to/setup-rstudio-github.html)
 
+## Python
+
+- [earthaccess](https://github.com/nsidc/earthaccess): Join us for our
+  [bi-weekly hack days](https://earthaccess.readthedocs.io/en/latest/work-with-us/#bi-weekly-alternating-weeks-earthaccess-hack-days)!
+
 ## Screen recording
 
 Thanks to Emma Ganley and Sam Csik for versions of this tip.


### PR DESCRIPTION
The linked hack day page doesn't exist yet; it will soon when this PR is merged: https://github.com/nsidc/earthaccess/pull/514