### PR TITLE
Add fall switchover to data academy approach guide

### DIFF
--- a/data-academy/index.qmd
+++ b/data-academy/index.qmd
@@ -1,9 +1,11 @@
 ---
 title: Data Academy
 format: html
+toc-depth: 4
+toc-expand: true
 ---
 
-We ran a [Data Academy for NOAA Fisheries](https://nmfs-openscapes.github.io/data-academy) in 2025, where a cohort of learners used [dataquest](https://www.dataquest.io/) to learn the basics of R and data science.
+We ran a [Data Academy for NOAA Fisheries](https://nmfs-openscapes.github.io/data-academy) in 2025, where two cohorts of learners used [dataquest](https://www.dataquest.io/) to learn the basics of R and data science.
 
 ## POP
 
@@ -13,6 +15,17 @@ We ran a [Data Academy for NOAA Fisheries](https://nmfs-openscapes.github.io/dat
 
 ## Overview and basic structure
 
+We ran two cohorts, one in the Spring/Summer (April - August), and one in the Fall (August - December).
+The Spring Cohort was designed for absolute beginners to R, and covers the basics of R programming and data visualization, 
+while the Fall Cohort is designed for those with some R experience, and is intented to be more self-directed.
+
+## Planning
+
+We recorded our planning steps and meeting notes in our [planning doc](https://docs.google.com/document/d/1S_XuI-HGrckq8ySwFvmdQAmBdfMztqBIQ9K5eyfooDs). 
+We modeled the cohort after a similar initiative at the Bureau of Labour Statistics, and we got lots of good advice from them.
+
+## Spring 2025 Cohort
+
 We ran a 15 week session, where learners had access to the full dataquest platform. 
 We decided on a [curriculum](#curriculum), which they followed through a weekly cadence of lessons. 
 We had weekly "[Help Desk](#help-desk)" sessions on Wednesdays, and set up a Google Space for chat and Q&A. 
@@ -20,12 +33,7 @@ Each Monday morning we sent an [email](#weekly-emails) with the tasks and inform
 
 **Expected time commitment**: Weekly for 3 months: 2-hour chunks of learning time, plus optional 1 hour of support from a "help desk" and coworking.
 
-## Planning
-
-We recorded our planning steps and meeting notes in our [planning doc](https://docs.google.com/document/d/1S_XuI-HGrckq8ySwFvmdQAmBdfMztqBIQ9K5eyfooDs). 
-We modeled the cohort after a similar initiative at the Bureau of Labour Statistics, and we got lots of good advice from them.
-
-## Participant Selection & Cohort Administration
+### Participant Selection & Cohort Administration
 
 We asked NMFS Mentors to share the opportunities with their colleagues:
 
@@ -54,7 +62,7 @@ Please share with your colleagues about the upcoming [NMFS Openscapes Data Acade
 
 **Cost**: Free. There is no cost to staff or your center/office. This opportunity is supported by NOAA funding to Openscapes.
 
-**How to apply:** If you’re interested in participating, please add yourself to the interest sheet: [DataAcademy\_Interest\_Spring2025 \[ nmfs-openscapes \]](https://docs.google.com/spreadsheets/d/1Kzl6akKd030oz-qPzBrikVbHyrjOLR7EgG5emSDkq9Q/edit?gid=0#gid=0). Deadline to apply is close of business, March 24\. Selected applicants will be notified April 1\. The 40 available spots will be distributed across centers and offices. Participants will be selected by the Openscapes team with input from NMFS Open Science staff and NMFS Openscapes Mentors. If people decline their offer to participate, we will select people from the waitlist, prioritizing people from the same division.
+**How to apply:** If you’re interested in participating, please add yourself to the interest sheet: [DataAcademy\_Interest\_Spring2025 \[ nmfs-openscapes \]](https://docs.google.com/spreadsheets/d/1Kzl6akKd030oz-qPzBrikVbHyrjOLR7EgG5emSDkq9Q). Deadline to apply is close of business, March 24\. Selected applicants will be notified April 1\. The 40 available spots will be distributed across centers and offices. Participants will be selected by the Openscapes team with input from NMFS Open Science staff and NMFS Openscapes Mentors. If people decline their offer to participate, we will select people from the waitlist, prioritizing people from the same division.
 
 **Frequently asked questions** and details of the curriculum are listed on the [NMFS Openscapes Data Academy page](https://nmfs-openscapes.github.io/data-academy). 
 
@@ -68,7 +76,7 @@ Eli Holmes, Jon Peake, NMFS Open Science & NMFS Openscapes
 
 :::
 
-People who were interested in participating signed up in the [interest sheet](https://docs.google.com/spreadsheets/d/1Kzl6akKd030oz-qPzBrikVbHyrjOLR7EgG5emSDkq9Q/edit?usp=drive_link).
+People who were interested in participating signed up in the [interest sheet](https://docs.google.com/spreadsheets/d/1Kzl6akKd030oz-qPzBrikVbHyrjOLR7EgG5emSDkq9Q).
 In signing up, participants wrote their learning goals, from which we attempted to infer their experience level (1 = true beginner, 2 = uncertain, 3 = more experienced). 
 We then asked them to return to the spreadsheet and confirm their experience level, and/or optionally remove themselves from consideration for the first cohort.
 
@@ -78,9 +86,9 @@ We then asked them to return to the spreadsheet and confirm their experience lev
 
 Hi All\!
 
-We’re thrilled to see your interest in increasing your R skills and that \>150 people have applied to participate in our first NMFS Openscapes Data Academy\! With only 40 spots available at a time, we have decided to focus Cohort 1 this spring for “true R beginners” with little or no coding experience and hold 3 additional cohorts in the next 12 months for other R learners. The [Data Academy cohorts 2025 doc](https://docs.google.com/document/d/1iQY1JpUZ9Ku2xF_Qb3jwxrCqFFAGYXn0_VqECOOEM3Q/edit?tab=t.0) outlines the plan for each cohort.
+We’re thrilled to see your interest in increasing your R skills and that \>150 people have applied to participate in our first NMFS Openscapes Data Academy\! With only 40 spots available at a time, we have decided to focus Cohort 1 this spring for “true R beginners” with little or no coding experience and hold 3 additional cohorts in the next 12 months for other R learners. The [Data Academy cohorts 2025 doc](https://docs.google.com/document/d/1iQY1JpUZ9Ku2xF_Qb3jwxrCqFFAGYXn0_VqECOOEM3Q) outlines the plan for each cohort.
 
-**Now we need your help to self-assess so we can select 40 “true beginners” for Cohort 1\.** Please review your Cohort assignment (inferred skill level) in [DataAcademy\_Interest\_Spring2025 \[ nmfs-openscapes \]](https://docs.google.com/spreadsheets/d/1Kzl6akKd030oz-qPzBrikVbHyrjOLR7EgG5emSDkq9Q/edit?gid=0#gid=0); we currently have \>40 applicants labeled as Cohort 1\. Assignments were based on your responses to “briefly describe your learning goals for the data academy”, then we (Julie, Andy, Stef, Eli, Jon) assigned cohorts. Have we mis-assigned your skill level? Are you no longer able to commit to \~3 hours a week from April 14 \- July 17, 2025 and need to opt out? Please indicate any changes in the spreadsheet COLUMN G and confirm you have reviewed it in COLUMN H by April 7 close of business. After that, we will distribute the 40 available spots across centers and offices and email Cohort 1 with next steps. 
+**Now we need your help to self-assess so we can select 40 “true beginners” for Cohort 1\.** Please review your Cohort assignment (inferred skill level) in [DataAcademy\_Interest\_Spring2025 \[ nmfs-openscapes \]](https://docs.google.com/spreadsheets/d/1Kzl6akKd030oz-qPzBrikVbHyrjOLR7EgG5emSDkq9Q); we currently have \>40 applicants labeled as Cohort 1\. Assignments were based on your responses to “briefly describe your learning goals for the data academy”, then we (Julie, Andy, Stef, Eli, Jon) assigned cohorts. Have we mis-assigned your skill level? Are you no longer able to commit to \~3 hours a week from April 14 \- July 17, 2025 and need to opt out? Please indicate any changes in the spreadsheet COLUMN G and confirm you have reviewed it in COLUMN H by April 7 close of business. After that, we will distribute the 40 available spots across centers and offices and email Cohort 1 with next steps. 
 
 Folks who are not participating in a current cohort can get great support from the NMFS Open Science Help Desk & R User Group. Check out the NMFS Open Science [Training page](https://sites.google.com/noaa.gov/nmfs-hq-st-open-science/trainings) for these and other opportunities.
 
@@ -101,7 +109,7 @@ This Google Group was used for sending mass emails to particpants.
 
 Particpants were also added to a NOAA [Google Chat Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg), for asynchronous help and cooperative learning.
 
-## Pre-cohort Engagement
+### Pre-cohort Engagement
 
 Applicants who were selected were sent this email:
 
@@ -122,7 +130,7 @@ We are doubling our level-1 R beginners cohort size to 80 people to meet the dem
 
 **Action items.**
 
-1. **If you can no longer actively participate, please reply immediately to this email** so we can give your spot to another R beginner. [DataAcademy\_Interest\_Spring2025 \[ nmfs-openscapes \]](https://docs.google.com/spreadsheets/d/1Kzl6akKd030oz-qPzBrikVbHyrjOLR7EgG5emSDkq9Q/edit?gid=0#gid=0) lists who else will be participating alongside you.   
+1. **If you can no longer actively participate, please reply immediately to this email** so we can give your spot to another R beginner. [DataAcademy\_Interest\_Spring2025 \[ nmfs-openscapes \]](https://docs.google.com/spreadsheets/d/1Kzl6akKd030oz-qPzBrikVbHyrjOLR7EgG5emSDkq9Q) lists who else will be participating alongside you.   
 2. **Check that you’ve received Google Calendar invites for our weekly help desk sessions**. If you have not received these invites, please let us know. We will meet remotely via Zoom, which you can do from the browser without installing any software.
 
 **Additional Information.**  
@@ -157,45 +165,13 @@ Eli Holmes, Jon Peake, NMFS Open Science
 
 :::
 
-## dataquest.io Setup and Administration
-
-### General
-
-*   Licences are $283 / year
-*   The [dataquest Teams FAQ](https://support.dataquest.io/en/categories/18-teams-faq) is helpful.
-*   Email `teams@dataquest.io` with anything; they’ll get back to us in 24 hours
-*   Chandra AI is pretty good for in-lesson help (in lower left as working through courses)  
-*   There is a voice screenreader in the courses, some learners found it very helpful.
-*   API to download metrics on learners' progress for reporting. 
-    Scripts and instructions are kept in the [nmfs-openscapes/data-academy repo](https://github.com/nmfs-openscapes/data-academy)
-
-### Steps
-
-*   Set up account at [dataquest.io Teams](https://www.dataquest.io/for-business/)
-*   We didn’t start with a pilot so that was unusual and caused some hiccups getting access to the account. 
-    A few emails and a Zoom meeting got things sorted.
-*   Julie is the account owner, Andy and Ileana were admins
-*   They created a custom learning path for us, which consisted of two existing Skills Paths: R Basics for Data Analysis + Data Visualization with R
-*   Created custom banner and certificate template
-*   Created bulk upload csv files at: - [DataQuest-bulk-upload](https://docs.google.com/spreadsheets/d/11SD1frhnRjZmX2GELjp72jYt0eCBt5R3Ixv5k--q0EQ/edit?gid=115415807#gid=115415807)
-*   Added learners via csv upload, once all in, emailed `teams@dataquest.io` to get licenses added, we were sent the invoice. They turned off auto-renewal.
-*   Learners and helpers were given licenses so we could do the lessons
-
-### Adding and removing people
-
-- Additions and removals annotated manually in the signup sheet [DataAcademy\_Interest\_Spring2025 \[ nmfs-openscapes \]](https://docs.google.com/spreadsheets/d/1Kzl6akKd030oz-qPzBrikVbHyrjOLR7EgG5emSDkq9Q/edit?gid=0#gid=0)  
-- Dataquest initially enrolled the cohort in the custom learning path, but people added after that needed to be added manually:  
-![](images/dataquest-enroll-custom-path.png){ height=200px }
-- Google Group (Openscapes) is not linked to Google Space (NMFS) - Andy thought he was also adding to the latter when he added to the former
-
-
-## Curriculum
+### Curriculum
 
 Dataquest offers many different "Learning Paths", including [Career Paths](https://www.dataquest.io/data-science-courses/career-paths/) and [Skill Paths](https://www.dataquest.io/data-science-courses/career-paths/). These Paths are composed of one or more courses, each of which consist of several lessons.
 
-Participants complete two Skill Paths (view as [weekly spreadsheet](https://docs.google.com/spreadsheets/d/1CVpthda3gOVT57nTOfdXjXuAr0vwc5k7avQtDJu-K8I/edit?gid=0#gid=0)):
+Participants complete two Skill Paths (view as [weekly spreadsheet](https://docs.google.com/spreadsheets/d/1CVpthda3gOVT57nTOfdXjXuAr0vwc5k7avQtDJu-K8I)):
 
-#### [R Basics for Data Analysis](https://www.dataquest.io/path/r-basics-for-data-analysis/) (4 courses)
+##### [R Basics for Data Analysis](https://www.dataquest.io/path/r-basics-for-data-analysis/) (4 courses)
 
 -   [Introduction to Data Analysis in R](https://www.dataquest.io/course/intro-to-r-rewrite/) (weeks 1-3)
 -   [Data Structures in R](https://www.dataquest.io/course/datastructure-in-r-rewrite/) (weeks 3-7)
@@ -203,7 +179,7 @@ Participants complete two Skill Paths (view as [weekly spreadsheet](https://docs
 -   **BREAK WEEK**
 -   [Specialized Data Processing in R](https://www.dataquest.io/course/intermediate-r-part-two/) (weeks 11-12)
 
-#### [Data Visualization with R](https://www.dataquest.io/path/data-visualization-with-r/) (1 course)
+##### [Data Visualization with R](https://www.dataquest.io/path/data-visualization-with-r/) (1 course)
 
 -   [Introduction to Data Visualization in R](https://www.dataquest.io/course/r-data-viz/) (weeks 13-15)
 
@@ -213,9 +189,9 @@ Participants have access to the full dataquest.io library of courses in addition
 -   [Introduction to Git and Version Control](https://www.dataquest.io/course/git-and-vcs/)
 -   [Querying Databases with SQL and R](https://www.dataquest.io/course/querying-databases-with-r/)
 
-## Cohort Engagement
+### Cohort Engagement
 
-### Weekly Emails
+#### Weekly Emails
 
 Each Monday morning we sent an email with:
 
@@ -226,7 +202,7 @@ Each Monday morning we sent an email with:
 
 ::: {.callout-tip collapse="true"}
 
-### Email for participants \- Week 1:
+## Email for participants \- Week 1:
 
 To: All 80 participants  
 From: Andy  
@@ -274,7 +250,7 @@ Eli Holmes, Jon Peake (NMFS Open Science)
 
 ::: {.callout-tip collapse="true"}
 
-### Email for participants \- Week 2:
+## Email for participants \- Week 2:
 
 To: All 80 participants  
 From: Andy  
@@ -311,7 +287,7 @@ Andy Teucher, Ileana Fenwick, Julie Lowndes, Stefanie Butland
 
 ::: {.callout-tip collapse="true"}
 
-### Email for participants \- Week 3:
+## Email for participants \- Week 3:
 
 To: All 80 participants  
 From: Andy  
@@ -329,7 +305,7 @@ Hello, and welcome to Week 3 of the 2025 [NMFS Openscapes Data Academy](https://
   * Wednesday April 30, 1-2pm PT. [https://zoom.us/j/91025564590](https://zoom.us/j/91025564590)  
 * **Ongoing asynchronous discussion** in our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE)
 
-Help Desk sessions remain small so far, so lots of space to chat and ask questions if you want to join us\! I anticipate that as lessons get more complex the sessions will get busier\! You can see our collaborative notes document [here](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/edit?tab=t.0) \- we will add to this each week when we meet. Also remember that our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE) is a great place to ask (and help answer) questions between Help Desk sessions\!
+Help Desk sessions remain small so far, so lots of space to chat and ask questions if you want to join us\! I anticipate that as lessons get more complex the sessions will get busier\! You can see our collaborative notes document [here](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI) \- we will add to this each week when we meet. Also remember that our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE) is a great place to ask (and help answer) questions between Help Desk sessions\!
 
 Have a great week, and we’d love to see you in the Help Desk session on Wednesday if you would like to join us\!
 
@@ -340,7 +316,7 @@ Andy Teucher, Ileana Fenwick, Julie Lowndes, Stefanie Butland
 
 ::: {.callout-tip collapse="true"}
 
-### Email for participants \- Week 4:
+## Email for participants \- Week 4:
 
 To: All 80 participants  
 From: Andy  
@@ -354,7 +330,7 @@ Hello, and welcome to Week 4 of the 2025 [NMFS Openscapes Data Academy](https://
   * Lesson 2 of [Data Structures in R](https://www.dataquest.io/course/datastructure-in-r-rewrite/): [Matrics](https://app.dataquest.io/c/92/m/503)  
 *  **Help Desk :**  
   * Wednesday May 7, 12-1pm PT. [https://zoom.us/j/91025564590](https://zoom.us/j/91025564590)  
-  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/edit?tab=t.0)  
+  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI)  
 * **Ongoing asynchronous discussion** in our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE)
 
 For those who want to know what's ahead, here is our [full weekly plan](https://docs.google.com/spreadsheets/d/1CVpthda3gOVT57nTOfdXjXuAr0vwc5k7avQtDJu-K8I/edit?usp=sharing) for working through the Intro to R and Data Visualization with R learning path in dataquest. If you are having trouble keeping up, feel free to reach out directly to me or Ileana and we would love to help you.
@@ -367,7 +343,7 @@ Andy Teucher, Ileana Fenwick, Julie Lowndes, Stefanie Butland
 
 ::: {.callout-tip collapse="true"}
 
-### Email for participants \- Week 5:
+## Email for participants \- Week 5:
 
 To: All 80 participants  
 From: Andy  
@@ -381,7 +357,7 @@ Hello, and welcome to Week 5 of the 2025 [NMFS Openscapes Data Academy](https://
   * Lesson 2 of [Data Structures in R](https://www.dataquest.io/course/datastructure-in-r-rewrite/): [Lists](https://app.dataquest.io/c/92/m/504)  
 *  **Help Desk :**  
   * Wednesday May 14, 1-2pm PT. [https://zoom.us/j/91025564590](https://zoom.us/j/91025564590)  
-  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/edit?tab=t.0)  
+  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI)  
 * **Ongoing asynchronous discussion** in our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE)
 
 We are going to try something new in the Help Desk sessions going forward: Starting this week  Ileana or I will walk through one or two of the sections in the lesson(s) from the week \- this week it is “Lists”. Lists in R are a bit of a strange animal if you haven’t encountered them before, so we will talk through some of the trickier bits of the lesson.
@@ -394,7 +370,7 @@ Andy Teucher, Ileana Fenwick, Julie Lowndes, Stefanie Butland
 
 ::: {.callout-tip collapse="true"}
 
-### Email for participants \- Week 6:
+## Email for participants \- Week 6:
 
 To: All 80 participants  
 From: Andy  
@@ -408,7 +384,7 @@ Hello, and welcome to Week 6 of the 2025 [NMFS Openscapes Data Academy](https://
   * Lesson 4 of [Data Structures in R](https://www.dataquest.io/course/datastructure-in-r-rewrite/): [Dataframes](https://app.dataquest.io/c/92/m/493)  
 *  **Help Desk :**  
   * Wednesday May 20, 12-1pm PT. [https://zoom.us/j/91025564590](https://zoom.us/j/91025564590)  
-  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/edit?tab=t.0)  
+  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI)  
 * **Ongoing asynchronous discussion** in our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE)
 
 Last week Ileana and I walked through some of the trickier parts of the "Lists" lessons, and there was lots of good discussion\! This week we will do the same for Data Frames. Data Frames are a fundamental structure in data analysis, and I hope this week you will start to see how they will apply to your work in a more tangible way.  
@@ -420,7 +396,7 @@ Andy Teucher, Ileana Fenwick, Julie Lowndes, Stefanie Butland
 
 ::: {.callout-tip collapse="true"}
 
-### Email for participants \- Week 7:
+## Email for participants \- Week 7:
 
 To: All 80 participants  
 From: Andy  
@@ -435,7 +411,7 @@ Hello, and welcome to Week 7 of the 2025 [NMFS Openscapes Data Academy](https://
   * Lesson 5 of [Data Structures in R](https://www.dataquest.io/course/datastructure-in-r-rewrite/): [Guided Project: Investigating COVID-19 Virus Trends](https://app.dataquest.io/c/92/m/505)  
 *  **Help Desk :**  
   * Wednesday May 28, 1-2pm PT. [https://zoom.us/j/91025564590](https://zoom.us/j/91025564590)  
-  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/edit?tab=t.0)  
+  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/)  
 * **Ongoing asynchronous discussion** in our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE)
 
 The guided project in this week’s lesson brings together a lot of the concepts you’ve learned in the preceding weeks. It may take you a bit more time as you actively practice and build on the skills we have learned so far, and that’s okay. There are many ways to get help if you need it\! You can post in the Google Space so everyone can benefit from the conversation, and please do come to the Help Desk on Wednesday if you can. People have had good luck with the Chandra AI assistant in the dataquest platform, and dataquest links to their version of the solution in the last page of the lesson. I have also put my version on [GitHub](https://github.com/nmfs-openscapes/data-academy/tree/main/guided-projects).
@@ -446,13 +422,13 @@ Cheers,
 Andy Teucher, Ileana Fenwick, Cassie Nickles, Julie Lowndes, Stefanie Butland
 
 PS:   
-We had originally planned to have two lessons this week, but since the guided project is a fairly heavy task and it’s a short week due to the holiday, we have decided to push the first lesson of [Control Flow, Iterations, and Functions](https://www.dataquest.io/course/intermediate-r/) to next week. We’ve updated the [curriculum schedule](https://docs.google.com/spreadsheets/d/1CVpthda3gOVT57nTOfdXjXuAr0vwc5k7avQtDJu-K8I/edit?gid=0#gid=0) accordingly.
+We had originally planned to have two lessons this week, but since the guided project is a fairly heavy task and it’s a short week due to the holiday, we have decided to push the first lesson of [Control Flow, Iterations, and Functions](https://www.dataquest.io/course/intermediate-r/) to next week. We’ve updated the [curriculum schedule](https://docs.google.com/spreadsheets/d/1CVpthda3gOVT57nTOfdXjXuAr0vwc5k7avQtDJu-K8I) accordingly.
 
 :::
 
 ::: {.callout-tip collapse="true"}
 
-### Email for participants \- Week 8:
+## Email for participants \- Week 8:
 
 To: All 80 participants  
 From: Andy  
@@ -468,7 +444,7 @@ Hello, and welcome to Week 8 of the 2025 [NMFS Openscapes Data Academy](https://
   * Lesson 2: [Iterations in R](https://app.dataquest.io/c/88/m/514)  
 *  **Help Desk :**  
   * Wednesday May 28, 1-2pm PT. [https://zoom.us/j/91025564590](https://zoom.us/j/91025564590)  
-  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/edit?tab=t.0).  
+  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/).  
   * We will have space for questions and discussion, breakout rooms for quiet work or specific help, and we’ll walk through some of the thornier bits of this week’s lessons.   
 * **Ongoing asynchronous discussion** in our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE)
 
@@ -481,7 +457,7 @@ Andy Teucher, Ileana Fenwick, Cassie Nickles, Julie Lowndes, Stefanie Butland
 
 ::: {.callout-tip collapse="true"}
 
-### Email for participants \- Week 9:
+## Email for participants \- Week 9:
 
 To: All 80 participants  
 From: Andy  
@@ -497,7 +473,7 @@ Hello, and welcome to Week 9 of the 2025 [NMFS Openscapes Data Academy](https://
   * Lesson 2: [Guided Project: Creating An Efficient Data Analysis Workflow](https://app.dataquest.io/c/88/m/498)  
 *  **Help Desk :**  
   * Wednesday June 11, 1-2pm PT. [https://zoom.us/j/91025564590](https://zoom.us/j/91025564590)  
-  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/edit?tab=t.0).  
+  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/).  
   * We will have space for questions and discussion, breakout rooms for quiet work or specific help, and we’ll walk through some of the thornier bits of this week’s lessons.   
 * **Ongoing asynchronous discussion** in our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE)
 
@@ -510,7 +486,7 @@ Andy Teucher, Ileana Fenwick, Cassie Nickles, Julie Lowndes, Stefanie Butland
 
 ::: {.callout-tip collapse="true"}
 
-### Email for participants \- Week 10 (Break week):
+## Email for participants \- Week 10 (Break week):
 
 To: All 80 participants  
 From: Andy  
@@ -521,10 +497,10 @@ Hello, and welcome to Week 10 of the 2025 [NMFS Openscapes Data Academy](https:/
 
 **This week (June 16-20)**
 
-* We’re taking a break this week\! We recognize that keeping up this pace of lessons is a lot, and so we’ve decided to add in a week with no new lessons. Please take a breather, take some time to catch up if you need, and/or review things from previous weeks. We’ve updated the [curriculum](https://docs.google.com/spreadsheets/d/1CVpthda3gOVT57nTOfdXjXuAr0vwc5k7avQtDJu-K8I/edit?gid=0#gid=0) accordingly, and will extend the schedule by one additional week (wrapping up the scheduled lessons the week of July 21).   
+* We’re taking a break this week\! We recognize that keeping up this pace of lessons is a lot, and so we’ve decided to add in a week with no new lessons. Please take a breather, take some time to catch up if you need, and/or review things from previous weeks. We’ve updated the [curriculum](https://docs.google.com/spreadsheets/d/1CVpthda3gOVT57nTOfdXjXuAr0vwc5k7avQtDJu-K8I) accordingly, and will extend the schedule by one additional week (wrapping up the scheduled lessons the week of July 21).   
 *  **Help Desk :**  
   * Wednesday June 18, 12-1pm PT. [https://zoom.us/j/91025564590](https://zoom.us/j/91025564590)  
-  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/edit?tab=t.0).  
+  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/).  
   * We will be available for questions and discussions, make breakout rooms for quiet work or specific help, and give you any other support you need.   
 * **Ongoing asynchronous discussion** in our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE)
 
@@ -537,7 +513,7 @@ Andy Teucher, Ileana Fenwick, Cassie Nickles, Julie Lowndes, Stefanie Butland
 
 ::: {.callout-tip collapse="true"}
 
-### Email for participants \- Week 11:
+## Email for participants \- Week 11:
 
 To: All 80 participants  
 From: Andy  
@@ -553,7 +529,7 @@ Hello, and welcome to Week 11 of the 2025 [NMFS Openscapes Data Academy](https:/
   * Lesson 2: [Date and Time Manipulation in R: Fundamentals](https://app.dataquest.io/c/94/m/497)  
 *  **Help Desk :**  
   * Wednesday June 25, 1-2pm PT. [https://zoom.us/j/91025564590](https://zoom.us/j/91025564590)  
-  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/edit?tab=t.0).  
+  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/).  
   * We will have space for questions and discussion, breakout rooms for quiet work or specific help, and we’ll walk through some of the trickier bits of this week’s lessons.   
 * **Ongoing asynchronous discussion** in our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE)
 
@@ -567,7 +543,7 @@ Andy Teucher, Ileana Fenwick, Cassie Nickles, Julie Lowndes, Stefanie Butland
 
 ::: {.callout-tip collapse="true"}
 
-### Email for participants \- Week 12:
+## Email for participants \- Week 12:
 
 To: All 80 participants  
 From: Andy  
@@ -584,11 +560,94 @@ This week we are looking at a new way of iterating in R, using the `map()` funct
   * Lesson 4: [Guided Project: Creating An Efficient Data Analysis Workflow, Part 2](https://app.dataquest.io/c/94/m/516)  
 *  **Help Desk :**  
   * Wednesday July 2, 12-1pm PT. [https://zoom.us/j/91025564590](https://zoom.us/j/91025564590)  
-  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/edit?tab=t.0).  
+  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/).  
   * We will have space for questions and discussion, breakout rooms for quiet work or specific help, and we’ll walk through some of the trickier bits of this week’s lessons.   
 * **Ongoing asynchronous discussion** in our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE)
 
 Have a great week, and we’d love to see you in the Help Desk session on Wednesday if you would like to join us\!   
+Cheers,   
+Andy Teucher, Ileana Fenwick, Cassie Nickles, Julie Lowndes, Stefanie Butland
+
+:::
+
+::: {.callout-tip collapse="true"}
+
+## **Email for participants \- Week 13:**
+
+To: All 80 participants  
+From: Andy  
+Cc: Ileana, Cassie, Julie, Stef  
+Subject: Week 13 – NMFS Openscapes Data Academy\!
+
+Hello, and welcome to Week 13 of the 2025 [NMFS Openscapes Data Academy](https://nmfs-openscapes.github.io/data-academy.html)\! We are into some fun stuff this week: Visualization\! The powerful data visualization capabilities of R, especially using ggplot2, is one of the most compelling reasons to use R for data analysis. It makes it possible to create myriad publication-quality data visualizations using the “grammar of graphics” framework. It introduces a slightly different way of thinking about data visualization, which is very powerful, and also takes a bit of getting used to.  
+**This week (July 7 \- 11\)**
+
+* **Curriculum goals:** Lessons 1 and 2 of [Introduction to Data Visualization in R](https://www.dataquest.io/course/r-data-viz/):  
+  * Lesson 1: [Visualizing Data with ggplot2](https://app.dataquest.io/c/51/m/273)   
+  * Lesson 2: [Visualizing Data Distributions](https://app.dataquest.io/c/51/m/275)  
+*  **Help Desk :**  
+  * Wednesday July 9, 1-2pm PT. [https://zoom.us/j/91025564590](https://zoom.us/j/91025564590)  
+  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/).  
+  * In the main room we’ll walk through some of the trickier bits of this week’s lessons, and this demo will be recorded. We will also have space for questions and discussion, and breakout rooms for quiet work or specific help.  
+* **Ongoing asynchronous discussion** in our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE)
+
+Have a great week, and we’d love to see you in the Help Desk session on Wednesday if you would like to join us\!   
+Cheers,   
+Andy Teucher, Ileana Fenwick, Cassie Nickles, Julie Lowndes, Stefanie Butland
+
+::: 
+
+::: {.callout-tip collapse="true"}
+
+## **Email for participants \- Week 14:**
+
+To: All 80 participants  
+From: Andy  
+Cc: Ileana, Cassie, Julie, Stef  
+Subject: Week 14 – NMFS Openscapes Data Academy\!
+
+Hello, and welcome to Week 14 of the 2025 [NMFS Openscapes Data Academy](https://nmfs-openscapes.github.io/data-academy.html)\! This is our second-to-last week of our [curriculum schedule](https://docs.google.com/spreadsheets/d/1CVpthda3gOVT57nTOfdXjXuAr0vwc5k7avQtDJu-K8I), with the last two lessons on data visualization before the final guided project next week. You have access to the dataquest platform until Aug 17 to work towards your personal learning goals.  
+**This week (July 14 \- 18\)**
+
+* **Curriculum goals:** Lessons 3 and 4 of [Introduction to Data Visualization in R](https://www.dataquest.io/course/r-data-viz/):  
+  * Lesson 3: [Visualizing Relationships Between Variables](https://app.dataquest.io/c/51/m/274)   
+  * Lesson 4: [Improving your Visualizations](https://app.dataquest.io/c/51/m/276)  
+*  **Help Desk :**  
+  * Wednesday July 16, 12-1pm PT. [https://zoom.us/j/91025564590](https://zoom.us/j/91025564590)  
+  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/).  
+  * In the main room we’ll walk through some of the trickier bits of this week’s lessons, and this demo will be recorded. We will also have space for questions and discussion, and breakout rooms for quiet work or specific help.  
+  * Next week (July 23\) will be our last help desk session\!  
+* **Ongoing asynchronous discussion** in our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE)
+
+Have a great week, and we’d love to see you in the Help Desk session on Wednesday if you would like to join us\!   
+Cheers,   
+Andy Teucher, Ileana Fenwick, Cassie Nickles, Julie Lowndes, Stefanie Butland
+
+:::
+
+::: {.callout-tip collapse="true"}
+
+## **Email for participants \- Week 15:**
+
+To: All 80 participants  
+From: Andy  
+Cc: Ileana, Cassie, Julie, Stef  
+Subject: Week 15 – NMFS Openscapes Data Academy\!
+
+Hello, and welcome to Week 15 of the 2025 [NMFS Openscapes Data Academy](https://nmfs-openscapes.github.io/data-academy.html)\! This week wraps up the final lesson in the Data Visualization with R course, with a guided project. It is also our final Help Desk session\! If you’re not at this point in your own learning, don’t worry\! You still have access to the dataquest platform until August 17, and the [Google Space](https://chat.google.com/room/AAQA5_f7MGg?cls=7) will remain for you to ask questions and discuss the content. And if you don’t finish all of the [curriculum](https://docs.google.com/spreadsheets/d/1CVpthda3gOVT57nTOfdXjXuAr0vwc5k7avQtDJu-K8I) that was set out, that’s ok \- you are learning what you need as you are able, and that is great\!
+
+**This week (July 21 \- 25\)**
+
+* **Curriculum goals:** Lesson 5 of [Introduction to Data Visualization in R](https://www.dataquest.io/course/r-data-viz/):  
+  * Lesson 5: [Guided Project: Analyzing Forest Fire Data](https://app.dataquest.io/c/51/m/277/guided-project%3A-analyzing-forest-fire-data/1/exploring-data-through-visualizations-independent-investigations?path=33&slug=intro-to-r-data-visualization-custom&version=1)  
+*  **Help Desk :**  
+  * Wednesday July 23, 1-2pm PT. [https://zoom.us/j/91025564590](https://zoom.us/j/91025564590)  
+  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/).  
+  * In the main room we’ll walk through the guided project, and this demo will be recorded. We will also have space for questions and discussion, and breakout rooms for quiet work or specific help.  
+* **Ongoing asynchronous discussion** in our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE)
+
+Have a great week, and we’d love to see you in the Help Desk session on Wednesday if you would like to join us\!
+
 Cheers,   
 Andy Teucher, Ileana Fenwick, Cassie Nickles, Julie Lowndes, Stefanie Butland
 
@@ -627,7 +686,7 @@ Andy Teucher, Ileana Fenwick, Cassie Nickles, Julie Lowndes, Stefanie Butland
 
 :::
 
-### Google Space
+#### Google Space
 
 We created a Google Space in the NMFS organization, and used it for asynchronous
 chat and help. We posted reminders about the Help Desk sessions and other announcements, and links to Help Desk notes and recording after the sessions.
@@ -663,7 +722,7 @@ read_csv("file.csv")
 
 :::
 
-### Help Desk
+#### Help Desk
 
 We ran a weekly 1-hour help desk session on Wednesdays, alternating 12-1 pm and 1-2 pm PT.
 These time slots were chose to accomadate time zones from Alasaka to Eastern.
@@ -781,9 +840,9 @@ Room 4 \-
 
 :::
 
-### Mid-Course Survey
+#### Mid-Course Survey
 
-### Engagement with those falling behind
+#### Engagement with those falling behind
 
 In week 5, we identified about 20 people who had not so far started the curriculum (had less than 1 hour in the platform). 
 We wanted to help them if we could, and give them a way to gracefully give up their spot if they couldn't continue at this time.
@@ -801,7 +860,7 @@ I invite you to use either of the support options below or respond here and let 
 
 * Help Desk :  
   * Wednesday May 14, 12-1pm PT. [https://zoom.us/j/91025564590](https://zoom.us/j/91025564590)  
-  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/edit?tab=t.0)  
+  * Our shared [notes document](https://docs.google.com/document/d/17uEkQ-1MIDcBlGBzW_ROlyoKFZ2hJ8iy_4IC3ekKghI/)  
 * Ongoing asynchronous discussion in our [Google Space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg/APHglI80sBE/APHglI80sBE)
 
 
@@ -834,7 +893,167 @@ Andy Teucher, Ileana Fenwick, Julie Lowndes, Stefanie Butland
 
 :::
 
-Those that removed themselves from the course had this recorded in the [participants selection sheet](https://docs.google.com/spreadsheets/d/1Kzl6akKd030oz-qPzBrikVbHyrjOLR7EgG5emSDkq9Q/edit?gid=0#gid=0), as were those who were subsequently added. 
+Those that removed themselves from the course had this recorded in the [participants selection sheet](https://docs.google.com/spreadsheets/d/1Kzl6akKd030oz-qPzBrikVbHyrjOLR7EgG5emSDkq9Q), as were those who were subsequently added. 
+
+### Removing people from dataquest at the end of Spring Cohort
+
+At the end of the Spring cohort, we removed dataquest.io licenses for participants, to free up
+licenses for the [Fall 2025 Cohort]:
+
+::: {.callout-tip collapse="true"}
+
+## Email to those being removed from cohort 1: 
+
+Hello,
+
+
+We want to sincerely thank all of you and applaud you for your time, effort, and dedication to the NMFS Openscapes Data Academy. You all put in a lot of effort in what we know is a challenging time, and hope you got what you needed out of the course. We had a great time meeting and working with many of you in the Help Desk sessions and in the Google Chat space.
+
+
+We will be doing the switchover in dataquest.io today to allow a new cohort of learners to make use of the platform, and so you will no longer have access to all of the dataquest.io content. You will still have access to your certificates, and your progress will not be lost in case you come back to the platform. 
+
+
+You will keep your access to the Data Academy [Google Chat space](https://mail.google.com/chat/u/0/#chat/space/AAQA5_f7MGg) to continue the discussions and learning from one another.
+
+
+Please reply to me (Andy) if you have any questions or concerns.
+
+
+Thanks again,
+
+Andy, Ileana, Cassie, Stef
+
+:::
+
+## Fall 2025 Cohort
+
+The Fall Cohort is designed for those with some R experience, and is intented to be more self-directed. Participants can choose their own learning paths based on their interests and needs, and/or choose to follow the same [curriculum] as those in the Spring cohort.
+
+Participation in the Fall Cohort is tracked in the [DataAcademy\_Interest\_Fall2025 \[ nmfs-openscapes \]](https://docs.google.com/spreadsheets/d/1fy5qDSscm6GU1OA3nAV_MX5YB8TJmehsUwYRewXass4) sheet.
+
+Fall suggested curriculum schedule: [NMFS Data Academy Curriculum Fall 2025 \[data-academy-cohort\]](https://docs.google.com/spreadsheets/d/1YdE_khWiEr46fgdUyAG7GUg6fGBEAgQ9RRl9ac__0hQ).
+
+Particpants for the Fall cohort were selected from the waitlist of the Spring cohort.
+
+Support from Openscapes for the Fall cohort is lighter - periodic reminders about the curriculum, and weekly 1-hour help-desk sessions, but not with full demos and only one helper (Andy). No prep time for helper.
+
+::: {.callout-tip collapse="true"}
+
+## Email sent to wait list from Cohort 1:
+
+Hello\!
+
+We are reaching out because you previously expressed interest in the [NMFS-Openscapes Data Academy](https://nmfs-openscapes.github.io/data-academy) but were not selected for the first cohort. Our second cohort will be starting in August, and we would love it if you are able to join us\!
+
+**What**: You will learn R for data science through lessons on the [dataquest.io](http://dataquest.io/) platform. The Data Academy is **asynchronous** so you can complete the lessons on your own schedule each week, and also **cohort-based** so you’ll get to know and learn along with your colleagues. The Openscapes team will provide support through a weekly **synchronous help desk** and a **dedicated Google Space** for help and collaboration with other learners. 
+
+**Suggested Curriculum**: [https://nmfs-openscapes.github.io/data-academy.html\#curriculum](https://nmfs-openscapes.github.io/data-academy.html#curriculum)
+
+During the Data Academy, you will have access to the full [dataquest.io](http://dataquest.io/) library of courses in addition to the [R Curriculum](https://nmfs-openscapes.github.io/data-academy.html#curriculum). We expect many learners in this cohort may be more experienced, and so you are encouraged to find and complete the courses that best fit your learning needs. If you are a beginner, then the suggested curriculum is a great learning path for you. A training certificate will be issued for each course completed. 
+
+Participants in Cohort 2 will have less hands-on support than in Cohort 1\. This is a peer group learning experience with the Google Space for questions.
+
+You can also get great support from the NMFS Open Science Help Desk & R User Group. Check out the NMFS Open Science [Training page](https://sites.google.com/noaa.gov/nmfs-hq-st-open-science/trainings) for these and other opportunities, including weekly GitHub trainings, and Friday HackHours.
+
+**Expected time commitment**: Weekly for 15 weeks months: Approximately 2-hour chunks of learning time, plus 1 hour of optional support from a "help desk".  
+
+**When**: Aug 18  \-  Dec 19, 2025\. 
+
+* Complete lessons on your own schedule.  
+* Wednesdays: Help desk with the Openscapes team alongside other participants (Optional, via Zoom)
+
+**Cost**: Free. There is no cost to staff or your center/office. This opportunity is supported by NOAA funding to Openscapes.
+
+**How to confirm your participation:** If you’re interested in participating, please confirm in this Google sheet: [DataAcademy\_Interest\_Fall2025 \[ nmfs-openscapes \]](https://docs.google.com/spreadsheets/d/1fy5qDSscm6GU1OA3nAV_MX5YB8TJmehsUwYRewXass4). Choose “Yes” or “No” from the dropdown menu in the “Confirm Fall 2025” column (column H) beside your name. You may update your Skill Level in R in column G. The deadline to confirm is close of business, July 25\.  If you decline the offer to participate, we will select people from the waitlist, prioritizing people from the same division.
+
+Please let us know if you have any questions. Thank you for being a part of this; we’re looking forward to continuing skillbuilding and strengthening relationships and open science across NMFS.
+
+Cheers,  
+Stefanie Butland, Julie Lowndes, Andy Teucher, Openscapes  
+Eli Holmes, Jon Peake, NMFS Open Science & NMFS Openscapes
+
+:::
+
+There were also several people from Cohort 1 who had their access extended or reinstated:
+
+* Those who voluntarily removed themselves due to inability to commit to Cohort 1
+* Those who made little progress in Cohort 1 due to unforseen circumstances
+* A few very keen participants who wanted to keep learning and exploring more of the course catalogue.
+
+The intention is to keep some spots free, and/or free up spots from people who had extended access, so that Fall NMFS Champions can use some licenses if they are keen.
+
+::: {.callout-tip collapse="true"}
+
+## Welcome email to Cohort 2:  
+    
+Hello\!  
+  
+**We are excited to welcome you to the second cohort of the 2025 [NMFS Openscapes Data Academy](https://nmfs-openscapes.github.io/data-academy.html)**  
+  
+You will learn R for data science through lessons on the [dataquest.io](http://dataquest.io/) platform. The Openscapes team will provide support through a weekly **synchronous help desk** and a **dedicated Google Space** for help and collaboration with other learners. 
+
+
+During the Data Academy, you will have access to the full [dataquest.io](http://dataquest.io/) library of courses. We expect many learners in this cohort may be more experienced, so you are encouraged to find and complete the courses that best fit your learning needs. If you are a beginner, then the [**suggested curriculum**](https://nmfs-openscapes.github.io/data-academy.html#curriculum) is a great learning path for you. A training certificate will be issued for each course completed.
+
+**Suggested Curriculum for beginners**: [https://nmfs-openscapes.github.io/data-academy.html\#curriculum](https://nmfs-openscapes.github.io/data-academy.html#curriculum) (spreadsheet version: [NMFS Data Academy Curriculum Fall 2025 \[data-academy-cohort\]](https://docs.google.com/spreadsheets/d/1YdE_khWiEr46fgdUyAG7GUg6fGBEAgQ9RRl9ac__0hQ))  
+  
+**You will be added to the [dataquest.io](http://dataquest.io/) platform today (August 18\) with your NOAA email.** Once you have access, you will be able to start learning on your own schedule, either following the suggested curriculum or choosing your own learning path from any of the [dataquest.io](http://dataquest.io) courses.  
+**When**: Aug 18  \-  Dec 19, 2025\.
+
+* Complete lessons on your own schedule.  
+* Wednesdays: Help desk with the Openscapes team alongside other participants (Optional, via Zoom). You will receive a Google Calendar invite for these meetings.  
+  
+**If you can no longer actively participate, please reply immediately to this email** so we can give your spot to another learner.  
+  
+**All Openscapes events abide by our [Code of Conduct](https://openscapes.org/code-of-conduct).** We are dedicated to providing a positive learning environment for all. Please let us know if you require any accommodations or if there is anything we can do to make this cohort more accessible to you.  
+  
+Please let us know if you have any questions. Thank you for being a part of this; we’re looking forward to continuing skillbuilding and strengthening relationships and open science across NMFS.  
+  
+Cheers,  
+Andy Teucher, Stefanie Butland, Julie Lowndes, Openscapes  
+Eli Holmes, Jon Peake, NMFS Open Science & NMFS Openscapes
+
+:::
+
+### Spring - Fall Cohort switchover
+
+* Created new Google Group for Cohort 2 emails and calendar invites
+* Andy asked Eli to add new people to Google Space. Partipacants from Cohort 1 remained in the Google Space.
+* New Google Calendar invites for Help Desk sessions
+* Remove people from DataQuest  
+* Add new people to DataQuest  
+* Update Website
+
+## dataquest.io Setup and Administration
+
+### General
+
+*   Licences are $283 / year
+*   The [dataquest Teams FAQ](https://support.dataquest.io/en/categories/18-teams-faq) is helpful.
+*   Email `teams@dataquest.io` with anything; they’ll get back to us in 24 hours
+*   Chandra AI is pretty good for in-lesson help (in lower left as working through courses)  
+*   There is a voice screenreader in the courses, some learners found it very helpful.
+*   API to download metrics on learners' progress for reporting. 
+    Scripts and instructions are kept in the [nmfs-openscapes/data-academy repo](https://github.com/nmfs-openscapes/data-academy)
+
+### Steps
+
+*   Set up account at [dataquest.io Teams](https://www.dataquest.io/for-business/)
+*   We didn’t start with a pilot so that was unusual and caused some hiccups getting access to the account. 
+    A few emails and a Zoom meeting got things sorted.
+*   Julie is the account owner, Andy and Ileana were admins
+*   They created a custom learning path for us, which consisted of two existing Skills Paths: R Basics for Data Analysis + Data Visualization with R
+*   Created custom banner and certificate template
+*   Created bulk upload csv files at: - [DataQuest-bulk-upload](https://docs.google.com/spreadsheets/d/11SD1frhnRjZmX2GELjp72jYt0eCBt5R3Ixv5k--q0EQ)
+*   Added learners via csv upload, once all in, emailed `teams@dataquest.io` to get licenses added, we were sent the invoice. They turned off auto-renewal.
+*   Learners and helpers were given licenses so we could do the lessons
+
+### Adding and removing people
+
+- Additions and removals annotated manually in the signup sheet [DataAcademy\_Interest\_Spring2025 \[ nmfs-openscapes \]](https://docs.google.com/spreadsheets/d/1Kzl6akKd030oz-qPzBrikVbHyrjOLR7EgG5emSDkq9Q)  
+- Dataquest initially enrolled the cohort in the custom learning path, but people added after that needed to be added manually:  
+![](images/dataquest-enroll-custom-path.png){ height=200px }
+- Google Group (Openscapes) is not linked to Google Space (NMFS) - Andy thought he was also adding to the latter when he added to the former
 
 ## Tracking progess
 


### PR DESCRIPTION
Different to the data academy page, I kept this more linear since it outlines our steps rather than communicates the program. I did a bit more nesting of sections (especially with Spring Cohort), and put the dataquest admin, tracking progress, and lessons learned on their own at the end, since they are "cohort agnostic" (I think)